### PR TITLE
Add CI release build (without proprietary FPGA toolchains)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: tock-litex-ci
+on:
+  pull_request:
+  push:
+jobs:
+  ci-release-build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2.3.4
+
+    - uses: cachix/install-nix-action@v12
+      with:
+        nix_path: nixpkgs=channel:nixos-unstable
+
+    - run: nix-build --arg enableVivado false release.nix
+
+    - uses: actions/upload-artifact@v2
+      with:
+        name: release-build-novivado
+        # Glob required here, see https://github.com/actions/upload-artifact/issues/92
+        path: 'result*/*'


### PR DESCRIPTION
Automatically performs and uploads release builds, without any bitstreams built through proprietary toolchains.

This is not a vendor lock-in, given that only the regular Nix-based release build is started. It's rather convenient for people who don't have Nix installed though.